### PR TITLE
Implement track chunk generator

### DIFF
--- a/tasks.md
+++ b/tasks.md
@@ -12,7 +12,7 @@ Below is a high-level breakdown of the work needed to deliver the Token Trek gam
    - Add a camera and minimal lighting.
    - Create a placeholder player model.
 
-3. **Procedural Track Generation**
+3. **Procedural Track Generation** ✅ *Complete*
    - Implement a `trackChunkGenerator` that creates a 3‑lane endless track.
    - Write unit tests for the generator.
 

--- a/token-trek/src/game/__tests__/trackChunkGenerator.test.ts
+++ b/token-trek/src/game/__tests__/trackChunkGenerator.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { trackChunkGenerator } from '../trackChunkGenerator'
+
+describe('trackChunkGenerator', () => {
+  it('generates sequential chunks with default settings', () => {
+    const gen = trackChunkGenerator()
+    const first = gen.next().value
+    const second = gen.next().value
+    const third = gen.next().value
+    expect(first).toEqual({ id: 0, lanes: [-2, 0, 2], startZ: 0, length: 10 })
+    expect(second).toEqual({ id: 1, lanes: [-2, 0, 2], startZ: 10, length: 10 })
+    expect(third).toEqual({ id: 2, lanes: [-2, 0, 2], startZ: 20, length: 10 })
+  })
+
+  it('allows custom chunk length and lane width', () => {
+    const gen = trackChunkGenerator(5, 1.5)
+    const first = gen.next().value
+    const second = gen.next().value
+    expect(first).toEqual({ id: 0, lanes: [-1.5, 0, 1.5], startZ: 0, length: 5 })
+    expect(second).toEqual({ id: 1, lanes: [-1.5, 0, 1.5], startZ: 5, length: 5 })
+  })
+})

--- a/token-trek/src/game/trackChunkGenerator.ts
+++ b/token-trek/src/game/trackChunkGenerator.ts
@@ -1,0 +1,38 @@
+export interface TrackChunk {
+  /** unique id for the chunk */
+  id: number;
+  /** lane center positions along the X axis */
+  lanes: [number, number, number];
+  /** starting position of the chunk along the Z axis */
+  startZ: number;
+  /** length of the chunk */
+  length: number;
+}
+
+/**
+ * Generator for an endless 3-lane track.
+ *
+ * @param chunkLength - length of each track chunk
+ * @param laneWidth - distance between lane centers
+ */
+export function* trackChunkGenerator(
+  chunkLength = 10,
+  laneWidth = 2,
+): Generator<TrackChunk> {
+  let id = 0;
+  let startZ = 0;
+  const lanes: [number, number, number] = [
+    -laneWidth,
+    0,
+    laneWidth,
+  ];
+  while (true) {
+    yield {
+      id: id++,
+      lanes,
+      startZ,
+      length: chunkLength,
+    };
+    startZ += chunkLength;
+  }
+}


### PR DESCRIPTION
## Summary
- implement simple trackChunkGenerator returning endless 3-lane track
- add unit tests for generator
- mark Procedural Track Generation task as complete

## Testing
- `pnpm test`
- `pnpm lint`
- `pnpm build`
