### PR TITLE
Implement win condition and endgame

### DIFF
--- a/tasks.md
+++ b/tasks.md
@@ -49,7 +49,7 @@ Below is a high-level breakdown of the work needed to deliver the Token Trek gam
     - Bloom or glitch post‑processing with `EffectComposer`.
     - Maintain 60 FPS on typical laptop GPUs.
 
-11. **Game Over & Win State**
+11. **Game Over & Win State** ✅ *Complete*
     - Trigger win condition upon reaching an AGI milestone.
     - Show game over screen when the player loses all health.
 

--- a/token-trek/src/components/GameScene.tsx
+++ b/token-trek/src/components/GameScene.tsx
@@ -26,10 +26,12 @@ const GameScene: FC = () => {
   const wallRef           = useRef<Mesh>(null!)
 
   const isGameOver = useGameStore((s) => s.isGameOver)
+  const isGameWon = useGameStore((s) => s.isGameWon)
   const shrinkMaxHealth = useGameStore((s) => s.shrinkMaxHealth)
   const checkpointRef = useRef(0)
 
   useFrame(({ clock }) => {
+    if (isGameOver || isGameWon) return
     const elapsed = clock.getElapsedTime()
     if (elapsed - checkpointRef.current >= 15) {
       shrinkMaxHealth(10)
@@ -71,8 +73,8 @@ const GameScene: FC = () => {
         <OrbitControls />
       </Canvas>
 
-      {/* Simple overlay when the store flags game-over */}
-      {isGameOver && (
+      {/* Simple overlays when the store flags game-over or win */}
+      {(isGameOver || isGameWon) && (
         <div
           style={{
             position: 'absolute',
@@ -84,7 +86,7 @@ const GameScene: FC = () => {
             pointerEvents: 'none',
           }}
         >
-          Game Over
+          {isGameWon ? 'AGI Achieved!' : 'Game Over'}
         </div>
       )}
     </>

--- a/token-trek/src/components/HUD.tsx
+++ b/token-trek/src/components/HUD.tsx
@@ -1,5 +1,5 @@
 import type { FC, CSSProperties } from 'react'
-import { useGameStore } from '../store/gameStore'
+import { useGameStore, AGI_GOAL } from '../store/gameStore'
 import styles from './HUD.module.css'
 
 const HUD: FC = () => {
@@ -18,7 +18,7 @@ const HUD: FC = () => {
         <div className={styles.healthBar} style={barStyle} />
       </div>
       <div className={styles.stats}>
-        <div>Tokens: {tokenCount.toFixed(0)}</div>
+        <div>Tokens: {tokenCount.toFixed(0)} / {AGI_GOAL}</div>
         <div>T/s: {tokensPerSecond.toFixed(2)}</div>
       </div>
     </div>

--- a/token-trek/src/components/Player.tsx
+++ b/token-trek/src/components/Player.tsx
@@ -33,6 +33,7 @@ const Player: FC<PlayerProps> = ({ obstacles = [], ...props }) => {
   const setLane     = usePlayerStore((s) => s.setLane)
   const reduceHealth= useGameStore((s) => s.reduceHealth)
   const isGameOver  = useGameStore((s) => s.isGameOver)
+  const isGameWon   = useGameStore((s) => s.isGameWon)
 
   /* Keyboard controls */
   useEffect(() => {
@@ -52,7 +53,7 @@ const Player: FC<PlayerProps> = ({ obstacles = [], ...props }) => {
 
   /* Per-frame logic */
   useFrame((_, dt) => {
-    if (isGameOver) return
+    if (isGameOver || isGameWon) return
 
     const mesh = meshRef.current
     mesh.position.x = (-1 + lane) * LANE_WIDTH   // snap to lane

--- a/token-trek/src/components/RAGPortal.tsx
+++ b/token-trek/src/components/RAGPortal.tsx
@@ -16,6 +16,8 @@ const RAGPortal: FC<ThreeElements['mesh']> = (props) => {
   const lane = usePlayerStore((s) => s.lane)
   const setLane = usePlayerStore((s) => s.setLane)
   const activate = useGameStore((s) => s.activateRagPortal)
+  const isGameOver = useGameStore((s) => s.isGameOver)
+  const isGameWon = useGameStore((s) => s.isGameWon)
 
   const reset = () => {
     if (!meshRef.current) return
@@ -29,6 +31,7 @@ const RAGPortal: FC<ThreeElements['mesh']> = (props) => {
   }, [])
 
   useFrame((_, dt) => {
+    if (isGameOver || isGameWon) return
     const mesh = meshRef.current
     mesh.rotation.y += dt
     mesh.position.z -= SPEED * dt

--- a/token-trek/src/components/SystemPromptPowerUp.tsx
+++ b/token-trek/src/components/SystemPromptPowerUp.tsx
@@ -15,6 +15,8 @@ const SystemPromptPowerUp: FC<ThreeElements['mesh']> = (props) => {
   const meshRef = useRef<Mesh>(null!)
   const lane = usePlayerStore((s) => s.lane)
   const activate = useGameStore((s) => s.activateSystemPrompt)
+  const isGameOver = useGameStore((s) => s.isGameOver)
+  const isGameWon = useGameStore((s) => s.isGameWon)
 
   const reset = () => {
     if (!meshRef.current) return
@@ -28,6 +30,7 @@ const SystemPromptPowerUp: FC<ThreeElements['mesh']> = (props) => {
   }, [])
 
   useFrame((_, dt) => {
+    if (isGameOver || isGameWon) return
     const mesh = meshRef.current
     mesh.rotation.y += dt
     mesh.position.z -= SPEED * dt

--- a/token-trek/src/components/Token.tsx
+++ b/token-trek/src/components/Token.tsx
@@ -16,6 +16,8 @@ const Token: FC<ThreeElements['mesh']> = (props) => {
   const lane = usePlayerStore((s) => s.lane)
   const collectToken = useGameStore((s) => s.collectToken)
   const ragPortalActive = useGameStore((s) => s.ragPortalActive)
+  const isGameOver = useGameStore((s) => s.isGameOver)
+  const isGameWon = useGameStore((s) => s.isGameWon)
 
   const resetToken = useCallback(() => {
     if (!meshRef.current) return
@@ -30,6 +32,7 @@ const Token: FC<ThreeElements['mesh']> = (props) => {
   }, [resetToken])
 
   useFrame((_, delta) => {
+    if (isGameOver || isGameWon) return
     const mesh = meshRef.current
     mesh.rotation.y += delta * 2
     mesh.position.z -= (ragPortalActive ? SPEED * 1.5 : SPEED) * delta

--- a/token-trek/src/components/obstacles/PromptInjectionCube.tsx
+++ b/token-trek/src/components/obstacles/PromptInjectionCube.tsx
@@ -12,11 +12,14 @@ import { useGameStore } from '../../store/gameStore'
 const PromptInjectionCube: FC<ThreeElements['mesh']> = (props) => {
   const meshRef = useRef<Mesh>(null!)
   const active = useGameStore((s) => s.systemPromptActive)
+  const isGameOver = useGameStore((s) => s.isGameOver)
+  const isGameWon = useGameStore((s) => s.isGameWon)
 
   useEffect(() => {
     if (meshRef.current) meshRef.current.visible = !active
   }, [active])
   useFrame((_, delta) => {
+    if (isGameOver || isGameWon) return
     meshRef.current.rotation.x += delta
     meshRef.current.rotation.y += delta
   })

--- a/token-trek/src/components/obstacles/RateLimitGate.tsx
+++ b/token-trek/src/components/obstacles/RateLimitGate.tsx
@@ -3,6 +3,7 @@ import { useRef } from 'react'
 import type { ThreeElements } from '@react-three/fiber'
 import { useFrame } from '@react-three/fiber'
 import type { Mesh } from 'three'
+import { useGameStore } from '../../store/gameStore'
 
 /**
  * Two bars that slide together to block a lane.
@@ -10,7 +11,10 @@ import type { Mesh } from 'three'
 const RateLimitGate: FC<ThreeElements['group']> = (props) => {
   const leftRef = useRef<Mesh>(null!)
   const rightRef = useRef<Mesh>(null!)
+  const isGameOver = useGameStore((s) => s.isGameOver)
+  const isGameWon = useGameStore((s) => s.isGameWon)
   useFrame(({ clock }) => {
+    if (isGameOver || isGameWon) return
     const t = Math.sin(clock.getElapsedTime()) // -1..1
     const offset = 1 - Math.abs(t) // 0..1
     leftRef.current.position.x = -1 - offset

--- a/token-trek/src/components/obstacles/SequenceLengthWall.tsx
+++ b/token-trek/src/components/obstacles/SequenceLengthWall.tsx
@@ -3,6 +3,7 @@ import { useRef } from 'react'
 import type { ThreeElements } from '@react-three/fiber'
 import { useFrame } from '@react-three/fiber'
 import type { Mesh } from 'three'
+import { useGameStore } from '../../store/gameStore'
 
 /**
  * A wall that appears after a delay, forcing the player to jump.
@@ -15,7 +16,10 @@ interface Props extends MeshProps {
 
 const SequenceLengthWall: FC<Props> = ({ appearAfter = 30, ...props }) => {
   const meshRef = useRef<Mesh>(null!)
+  const isGameOver = useGameStore((s) => s.isGameOver)
+  const isGameWon = useGameStore((s) => s.isGameWon)
   useFrame(({ clock }) => {
+    if (isGameOver || isGameWon) return
     if (meshRef.current) {
       meshRef.current.visible = clock.getElapsedTime() >= appearAfter
     }


### PR DESCRIPTION
## Summary
- add `AGI_GOAL` constant and win tracking in game store
- show goal progress in HUD
- stop game logic when won or lost
- display win or game-over overlay
- mark task 11 as complete

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`
