### PR TITLE
Implement RAG Portal bonus lane

### DIFF
--- a/tasks.md
+++ b/tasks.md
@@ -119,7 +119,7 @@ request conflicts.
     - Display token progress as `token_count / 8192` per spec.
     - Show a win screen when the counter reaches 8192 tokens.
 
-16. **RAG Portal Enhancement**
+16. **RAG Portal Enhancement** ✅ *Complete*
     - Teleport the player to a temporary bonus lane filled with tokens.
     - Return to the normal lanes after the portal effect ends.
 

--- a/token-trek/src/components/Player.tsx
+++ b/token-trek/src/components/Player.tsx
@@ -10,6 +10,7 @@ import { useGameStore }   from '../store/gameStore'
 import { usePlayerStore } from '../store/playerStore'
 
 const LANE_WIDTH    = 2
+const BONUS_OFFSET  = 4
 const JUMP_VELOCITY = 8
 const GRAVITY       = -20
 const FLOOR_Y       = 0.5
@@ -34,6 +35,7 @@ const Player: FC<PlayerProps> = ({ obstacles = [], ...props }) => {
   const reduceHealth= useGameStore((s) => s.reduceHealth)
   const isGameOver  = useGameStore((s) => s.isGameOver)
   const isGameWon   = useGameStore((s) => s.isGameWon)
+  const ragPortalActive = useGameStore((s) => s.ragPortalActive)
 
   /* Keyboard controls */
   useEffect(() => {
@@ -56,7 +58,8 @@ const Player: FC<PlayerProps> = ({ obstacles = [], ...props }) => {
     if (isGameOver || isGameWon) return
 
     const mesh = meshRef.current
-    mesh.position.x = (-1 + lane) * LANE_WIDTH   // snap to lane
+    const offset = ragPortalActive ? BONUS_OFFSET : 0
+    mesh.position.x = (-1 + lane) * LANE_WIDTH + offset // snap to lane or bonus
 
     /* jump / gravity */
     if (jumping.current) {

--- a/token-trek/src/components/Token.tsx
+++ b/token-trek/src/components/Token.tsx
@@ -10,6 +10,7 @@ import { useTrackStore } from '../store/trackStore'
 const LANE_WIDTH = 2
 const SPEED = 5
 const lanes = [-LANE_WIDTH, 0, LANE_WIDTH]
+const BONUS_OFFSET = 4
 
 const Token: FC<ThreeElements['mesh']> = (props) => {
   const meshRef = useRef<Mesh>(null!)
@@ -23,7 +24,8 @@ const Token: FC<ThreeElements['mesh']> = (props) => {
   const resetToken = useCallback(() => {
     if (!meshRef.current) return
     const { x, z } = nextPosition(ragPortalActive ? lane : undefined)
-    meshRef.current.position.set(x, 0.5, z)
+    const offset = ragPortalActive ? BONUS_OFFSET : 0
+    meshRef.current.position.set(x + offset, 0.5, z)
   }, [nextPosition, ragPortalActive, lane])
 
   useEffect(() => {
@@ -39,10 +41,11 @@ const Token: FC<ThreeElements['mesh']> = (props) => {
       resetToken()
       return
     }
+    const offset = ragPortalActive ? BONUS_OFFSET : 0
     if (
       mesh.position.z <= 0 &&
       mesh.position.z > -1 &&
-      Math.abs(mesh.position.x - lanes[lane]) < 0.1
+      Math.abs(mesh.position.x - (lanes[lane] + offset)) < 0.1
     ) {
       collectToken()
       resetToken()


### PR DESCRIPTION
## Summary
- add bonus lane offset for RAG Portal power-up
- shift player and tokens into the bonus lane while the effect is active
- mark RAG Portal enhancement task complete

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`
