### PR TITLE
Implement game start menu and restart feature

### DIFF
--- a/tasks.md
+++ b/tasks.md
@@ -123,7 +123,7 @@ request conflicts.
     - Teleport the player to a temporary bonus lane filled with tokens.
     - Return to the normal lanes after the portal effect ends.
 
-17. **Game Flow & Restart**
+17. **Game Flow & Restart** ✅ *Complete*
     - Add a start menu and allow restarting after game over or win.
     - Store the best token count in `localStorage` as a high score.
 

--- a/token-trek/src/App.tsx
+++ b/token-trek/src/App.tsx
@@ -1,12 +1,35 @@
+import { useState } from 'react'
 import GameScene from './components/GameScene'
 import HUD from './components/HUD'
+import StartMenu from './components/StartMenu'
+import GameOverScreen from './components/GameOverScreen'
+import { useGameStore } from './store/gameStore'
 import './App.css'
 
 function App() {
+  const [started, setStarted] = useState(false)
+  const resetGame = useGameStore((s) => s.resetGame)
+  const isGameOver = useGameStore((s) => s.isGameOver)
+  const isGameWon = useGameStore((s) => s.isGameWon)
+
+  const start = () => {
+    resetGame()
+    setStarted(true)
+  }
+
+  const restart = () => {
+    resetGame()
+    setStarted(true)
+  }
+
+  const showEndScreen = started && (isGameOver || isGameWon)
+
   return (
     <>
-      <GameScene />
-      <HUD />
+      {started && <GameScene />}
+      {started && <HUD />}
+      {!started && <StartMenu onStart={start} />}
+      {showEndScreen && <GameOverScreen onRestart={restart} />}
     </>
   )
 }

--- a/token-trek/src/components/GameOverScreen.tsx
+++ b/token-trek/src/components/GameOverScreen.tsx
@@ -1,0 +1,34 @@
+import type { FC } from 'react'
+import { useGameStore } from '../store/gameStore'
+
+interface Props {
+  onRestart: () => void
+}
+
+const GameOverScreen: FC<Props> = ({ onRestart }) => {
+  const isGameWon = useGameStore((s) => s.isGameWon)
+  const tokenCount = useGameStore((s) => s.tokenCount)
+  const highScore = useGameStore((s) => s.highScore)
+
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        top: '50%',
+        left: '50%',
+        transform: 'translate(-50%, -50%)',
+        color: 'white',
+        textAlign: 'center',
+      }}
+    >
+      <div style={{ fontSize: '2rem', marginBottom: '1rem' }}>
+        {isGameWon ? 'AGI Achieved!' : 'Game Over'}
+      </div>
+      <div style={{ marginBottom: '0.5rem' }}>Tokens: {tokenCount.toFixed(0)}</div>
+      <div style={{ marginBottom: '1rem' }}>High Score: {highScore.toFixed(0)}</div>
+      <button onClick={onRestart}>Restart</button>
+    </div>
+  )
+}
+
+export default GameOverScreen

--- a/token-trek/src/components/GameScene.tsx
+++ b/token-trek/src/components/GameScene.tsx
@@ -114,23 +114,6 @@ const GameScene: FC = () => {
         {/* Controls */}
         <OrbitControls />
       </Canvas>
-
-      {/* Simple overlays when the store flags game-over or win */}
-      {(isGameOver || isGameWon) && (
-        <div
-          style={{
-            position: 'absolute',
-            top: '50%',
-            left: '50%',
-            transform: 'translate(-50%, -50%)',
-            color: 'white',
-            fontSize: '2rem',
-            pointerEvents: 'none',
-          }}
-        >
-          {isGameWon ? 'AGI Achieved!' : 'Game Over'}
-        </div>
-      )}
     </>
   )
 }

--- a/token-trek/src/components/StartMenu.tsx
+++ b/token-trek/src/components/StartMenu.tsx
@@ -1,0 +1,29 @@
+import type { FC } from 'react'
+import { useGameStore } from '../store/gameStore'
+
+interface Props {
+  onStart: () => void
+}
+
+const StartMenu: FC<Props> = ({ onStart }) => {
+  const highScore = useGameStore((s) => s.highScore)
+
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        top: '50%',
+        left: '50%',
+        transform: 'translate(-50%, -50%)',
+        color: 'white',
+        textAlign: 'center',
+      }}
+    >
+      <div style={{ fontSize: '2rem', marginBottom: '1rem' }}>Token Trek</div>
+      <div style={{ marginBottom: '0.5rem' }}>High Score: {highScore.toFixed(0)}</div>
+      <button onClick={onStart}>Start</button>
+    </div>
+  )
+}
+
+export default StartMenu

--- a/token-trek/src/store/gameStore.ts
+++ b/token-trek/src/store/gameStore.ts
@@ -30,6 +30,10 @@ interface GameState {
   startTime: number
   collectToken: () => void
   tokensPerSecond: () => number
+
+  /* Meta */
+  highScore: number
+  resetGame: () => void
 }
 
 export const useGameStore = create<GameState>((set, get) => ({
@@ -85,4 +89,29 @@ export const useGameStore = create<GameState>((set, get) => ({
     const elapsed = (performance.now() - get().startTime) / 1000
     return elapsed > 0 ? get().tokenCount / elapsed : 0
   },
+
+  /* ── meta ─────────────────────────────────────────────────────────── */
+  highScore:
+    typeof window === 'undefined'
+      ? 0
+      : Number(window.localStorage.getItem('highScore')) || 0,
+  resetGame: () =>
+    set((state) => {
+      const highScore =
+        state.tokenCount > state.highScore ? state.tokenCount : state.highScore
+      if (typeof window !== 'undefined')
+        window.localStorage.setItem('highScore', String(highScore))
+      return {
+        health: 100,
+        maxHealth: 100,
+        isGameOver: false,
+        isGameWon: false,
+        systemPromptActive: false,
+        ragPortalActive: false,
+        tokenCount: 0,
+        multiplier: 1,
+        startTime: performance.now(),
+        highScore,
+      }
+    }),
 }))


### PR DESCRIPTION
## Summary
- add StartMenu and GameOverScreen components
- manage high scores and full reset in game store
- hook up start and restart flow via App
- remove overlay from GameScene
- mark task 17 complete

## Testing
- `pnpm -C token-trek lint`
- `pnpm -C token-trek test`
- `pnpm -C token-trek build`
