### PR TITLE
Implement cleanup and error boundary

### DIFF
--- a/tasks.md
+++ b/tasks.md
@@ -131,6 +131,6 @@ request conflicts.
     - Provide placeholders for sound effects on token collect, collisions and power-ups.
     - Document where users can drop custom audio files.
 
-19. **Cleanup & Error Handling**
+19. **Cleanup & Error Handling** ✅ *Complete*
     - Clear any `setTimeout` timers when components unmount.
     - Add React error boundaries around the game scene to surface issues.

--- a/token-trek/src/App.tsx
+++ b/token-trek/src/App.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import GameScene from './components/GameScene'
+import ErrorBoundary from './components/ErrorBoundary'
 import HUD from './components/HUD'
 import StartMenu from './components/StartMenu'
 import GameOverScreen from './components/GameOverScreen'
@@ -26,7 +27,11 @@ function App() {
 
   return (
     <>
-      {started && <GameScene />}
+      {started && (
+        <ErrorBoundary>
+          <GameScene />
+        </ErrorBoundary>
+      )}
       {started && <HUD />}
       {!started && <StartMenu onStart={start} />}
       {showEndScreen && <GameOverScreen onRestart={restart} />}

--- a/token-trek/src/components/ErrorBoundary.tsx
+++ b/token-trek/src/components/ErrorBoundary.tsx
@@ -1,0 +1,31 @@
+import { Component, type ReactNode, type ErrorInfo } from 'react'
+
+interface Props {
+  fallback?: ReactNode
+  children: ReactNode
+}
+
+interface State {
+  hasError: boolean
+}
+
+class ErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false }
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true }
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error('Game error:', error, info)
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return this.props.fallback ?? <div>Something went wrong.</div>
+    }
+    return this.props.children
+  }
+}
+
+export default ErrorBoundary

--- a/token-trek/src/components/GameScene.tsx
+++ b/token-trek/src/components/GameScene.tsx
@@ -1,5 +1,5 @@
 import type { FC } from 'react'
-import { useRef, useState } from 'react'
+import { useRef, useState, useEffect } from 'react'
 import { Canvas, useFrame } from '@react-three/fiber'
 import { OrbitControls, Stats } from '@react-three/drei'
 import type { Mesh, Group } from 'three'
@@ -43,7 +43,14 @@ const GameScene: FC = () => {
   const isGameOver = useGameStore((s) => s.isGameOver)
   const isGameWon = useGameStore((s) => s.isGameWon)
   const shrinkMaxHealth = useGameStore((s) => s.shrinkMaxHealth)
+  const clearPowerUpTimers = useGameStore((s) => s.clearPowerUpTimers)
   const checkpointRef = useRef(0)
+
+  useEffect(() => {
+    return () => {
+      clearPowerUpTimers()
+    }
+  }, [clearPowerUpTimers])
 
   useFrame(({ clock }, dt) => {
     if (isGameOver || isGameWon) return


### PR DESCRIPTION
## Summary
- manage power-up timers in Zustand store
- clear timers when GameScene unmounts
- add a reusable `ErrorBoundary` component
- wrap `GameScene` with the new error boundary
- mark **Cleanup & Error Handling** task as complete

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`
