### PR TITLE
Fix readonly id error in TrackChunk

### DIFF
--- a/token-trek/src/components/GameScene.tsx
+++ b/token-trek/src/components/GameScene.tsx
@@ -86,7 +86,7 @@ const SceneContent: FC = () => {
       <NeonGrid />
       {chunks.map((chunk, i) => (
         <TrackChunk
-          key={i}
+          key={chunk.id}
           ref={(el) => {
             if (el) chunkRefs.current[i] = el
           }}

--- a/token-trek/src/components/TrackChunk.tsx
+++ b/token-trek/src/components/TrackChunk.tsx
@@ -7,7 +7,8 @@ import type { TrackChunk as ChunkData } from '../game/trackChunkGenerator'
 type Props = ThreeElements['group'] & ChunkData
 
 const TrackChunk = forwardRef<Group, Props>(
-  ({ lanes, length, startZ, ...props }, ref) => {
+  ({ lanes, length, startZ, id, ...props }, ref) => {
+    void id
     const laneWidth = Math.abs(lanes[1] - lanes[0])
     return (
       <group ref={ref} position={[0, 0, startZ]} {...props}>


### PR DESCRIPTION
## Summary
- avoid passing track chunk `id` prop to `<group>` objects
- use chunk id as React key when rendering

## Testing
- `pnpm lint`
- `pnpm test --run`
- `pnpm build`
