### PR TITLE
Fix r3f read-only id error

### DIFF
--- a/token-trek/src/components/GameScene.tsx
+++ b/token-trek/src/components/GameScene.tsx
@@ -99,7 +99,9 @@ const SceneContent: FC = () => {
           ref={(el) => {
             if (el) chunkRefs.current[i] = el
           }}
-          {...chunk}
+          lanes={chunk.lanes}
+          length={chunk.length}
+          startZ={chunk.startZ}
         />
       ))}
 

--- a/token-trek/src/components/TrackChunk.tsx
+++ b/token-trek/src/components/TrackChunk.tsx
@@ -4,11 +4,10 @@ import type { ThreeElements } from '@react-three/fiber'
 
 import type { TrackChunk as ChunkData } from '../game/trackChunkGenerator'
 
-type Props = ThreeElements['group'] & ChunkData
+type Props = ThreeElements['group'] & Omit<ChunkData, 'id'>
 
 const TrackChunk = forwardRef<Group, Props>(
-  ({ lanes, length, startZ, id, ...props }, ref) => {
-    void id
+  ({ lanes, length, startZ, ...props }, ref) => {
     const laneWidth = Math.abs(lanes[1] - lanes[0])
     return (
       <group ref={ref} position={[0, 0, startZ]} {...props}>


### PR DESCRIPTION
## Summary
- stop passing `id` prop down to `TrackChunk`
- update `TrackChunk` props to omit `id`

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`
