### PR TITLE
Fix null ref crashes for obstacles

### DIFF
--- a/token-trek/src/components/obstacles/PromptInjectionCube.tsx
+++ b/token-trek/src/components/obstacles/PromptInjectionCube.tsx
@@ -20,6 +20,7 @@ const PromptInjectionCube: FC<ThreeElements['mesh']> = (props) => {
   const nextPosition = useTrackStore((s) => s.nextPosition)
 
   const reset = useCallback(() => {
+    if (!meshRef.current) return
     const { x, z } = nextPosition()
     meshRef.current.position.set(x, 0.5, z)
   }, [nextPosition])
@@ -34,10 +35,12 @@ const PromptInjectionCube: FC<ThreeElements['mesh']> = (props) => {
 
   useFrame((_, delta) => {
     if (isGameOver || isGameWon) return
-    meshRef.current.rotation.x += delta
-    meshRef.current.rotation.y += delta
-    meshRef.current.position.z -= SPEED * delta
-    if (meshRef.current.position.z < -5) reset()
+    const mesh = meshRef.current
+    if (!mesh) return
+    mesh.rotation.x += delta
+    mesh.rotation.y += delta
+    mesh.position.z -= SPEED * delta
+    if (mesh.position.z < -5) reset()
   })
 
   return (

--- a/token-trek/src/components/obstacles/SequenceLengthWall.tsx
+++ b/token-trek/src/components/obstacles/SequenceLengthWall.tsx
@@ -25,6 +25,7 @@ const SequenceLengthWall: FC<Props> = ({ appearAfter = 30, ...props }) => {
   const startTime = useRef<number>(0)
 
   const reset = useCallback((clockTime: number) => {
+    if (!meshRef.current) return
     const { x, z } = nextPosition()
     meshRef.current.position.set(x, 1, z)
     meshRef.current.visible = false
@@ -37,10 +38,12 @@ const SequenceLengthWall: FC<Props> = ({ appearAfter = 30, ...props }) => {
 
   useFrame(({ clock }, dt) => {
     if (isGameOver || isGameWon) return
+    const mesh = meshRef.current
+    if (!mesh) return
     const elapsed = clock.getElapsedTime() - startTime.current
-    if (elapsed >= appearAfter) meshRef.current.visible = true
-    meshRef.current.position.z -= SPEED * dt
-    if (meshRef.current.position.z < -5) reset(clock.getElapsedTime())
+    if (elapsed >= appearAfter) mesh.visible = true
+    mesh.position.z -= SPEED * dt
+    if (mesh.position.z < -5) reset(clock.getElapsedTime())
   })
 
   return (


### PR DESCRIPTION
## Summary
- guard obstacle meshes against missing refs

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`
