### PR TITLE
Add tasks for GameScene crash investigation

### DIFF
--- a/tasks.md
+++ b/tasks.md
@@ -134,3 +134,12 @@ request conflicts.
 19. **Cleanup & Error Handling** ✅ *Complete*
     - Clear any `setTimeout` timers when components unmount.
     - Add React error boundaries around the game scene to surface issues.
+
+20. **Stabilize GameScene**
+    - Investigate the runtime error "Cannot assign to read only property 'id'" that crashes the Canvas.
+    - Ensure components do not forward an `id` prop to three.js objects and remove any accidental mutations.
+    - Verify the scene no longer triggers the "Hooks can only be used within the Canvas component" warning.
+
+21. **Regression Tests for Game Launch**
+    - Add an integration test that mounts `GameScene` inside a testing canvas and asserts no errors are thrown.
+    - Run this test in CI to prevent future regressions.


### PR DESCRIPTION
## Summary
- add next steps for investigating Canvas crash
- note test coverage for future PRs

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`
