### PR TITLE
Complete task 20

### DIFF
--- a/tasks.md
+++ b/tasks.md
@@ -135,7 +135,7 @@ request conflicts.
     - Clear any `setTimeout` timers when components unmount.
     - Add React error boundaries around the game scene to surface issues.
 
-20. **Stabilize GameScene**
+20. **Stabilize GameScene** ✅ *Complete*
     - Investigate the runtime error "Cannot assign to read only property 'id'" that crashes the Canvas.
     - Ensure components do not forward an `id` prop to three.js objects and remove any accidental mutations.
     - Verify the scene no longer triggers the "Hooks can only be used within the Canvas component" warning.

--- a/token-trek/src/components/Obstacle.tsx
+++ b/token-trek/src/components/Obstacle.tsx
@@ -7,7 +7,9 @@ import { useGameStore } from '../store/gameStore'
 
 const SPEED = 5
 
-const Obstacle = forwardRef<Mesh, ThreeElements['mesh']>((props, ref) => {
+interface MeshProps extends Omit<ThreeElements['mesh'], 'id'> { id?: never }
+const Obstacle = forwardRef<Mesh, MeshProps>(({ id: _discard, ...props }, ref) => {
+  void _discard
   const meshRef = useRef<Mesh>(null!)
   const nextPosition = useTrackStore((s) => s.nextPosition)
   const isGameOver = useGameStore((s) => s.isGameOver)

--- a/token-trek/src/components/Player.tsx
+++ b/token-trek/src/components/Player.tsx
@@ -15,11 +15,13 @@ const JUMP_VELOCITY = 8
 const GRAVITY       = -20
 const FLOOR_Y       = 0.5
 
-type PlayerProps = ThreeElements['mesh'] & {
+interface MeshProps extends Omit<ThreeElements['mesh'], 'id'> { id?: never }
+type PlayerProps = MeshProps & {
   obstacles?: RefObject<Mesh>[]
 }
 
-const Player: FC<PlayerProps> = ({ obstacles = [], ...props }) => {
+const Player: FC<PlayerProps> = ({ id: _discard, obstacles = [], ...props }) => {
+  void _discard
   const meshRef        = useRef<Mesh>(null!)
   const velocityY      = useRef(0)
   const jumping        = useRef(false)

--- a/token-trek/src/components/RAGPortal.tsx
+++ b/token-trek/src/components/RAGPortal.tsx
@@ -12,7 +12,9 @@ const LANE_WIDTH = 2
 const SPEED = 5
 const lanes = [-LANE_WIDTH, 0, LANE_WIDTH]
 
-const RAGPortal: FC<ThreeElements['mesh']> = (props) => {
+interface MeshProps extends Omit<ThreeElements['mesh'], 'id'> { id?: never }
+const RAGPortal: FC<MeshProps> = ({ id: _discard, ...props }) => {
+  void _discard
   const meshRef = useRef<Mesh>(null!)
   const lane = usePlayerStore((s) => s.lane)
   const setLane = usePlayerStore((s) => s.setLane)

--- a/token-trek/src/components/SystemPromptPowerUp.tsx
+++ b/token-trek/src/components/SystemPromptPowerUp.tsx
@@ -12,7 +12,9 @@ const LANE_WIDTH = 2
 const SPEED = 5
 const lanes = [-LANE_WIDTH, 0, LANE_WIDTH]
 
-const SystemPromptPowerUp: FC<ThreeElements['mesh']> = (props) => {
+interface MeshProps extends Omit<ThreeElements['mesh'], 'id'> { id?: never }
+const SystemPromptPowerUp: FC<MeshProps> = ({ id: _discard, ...props }) => {
+  void _discard
   const meshRef = useRef<Mesh>(null!)
   const lane = usePlayerStore((s) => s.lane)
   const activate = useGameStore((s) => s.activateSystemPrompt)

--- a/token-trek/src/components/Token.tsx
+++ b/token-trek/src/components/Token.tsx
@@ -12,7 +12,9 @@ const SPEED = 5
 const lanes = [-LANE_WIDTH, 0, LANE_WIDTH]
 const BONUS_OFFSET = 4
 
-const Token: FC<ThreeElements['mesh']> = (props) => {
+interface MeshProps extends Omit<ThreeElements['mesh'], 'id'> { id?: never }
+const Token: FC<MeshProps> = ({ id: _discard, ...props }) => {
+  void _discard
   const meshRef = useRef<Mesh>(null!)
   const lane = usePlayerStore((s) => s.lane)
   const collectToken = useGameStore((s) => s.collectToken)

--- a/token-trek/src/components/TrackChunk.tsx
+++ b/token-trek/src/components/TrackChunk.tsx
@@ -4,10 +4,12 @@ import type { ThreeElements } from '@react-three/fiber'
 
 import type { TrackChunk as ChunkData } from '../game/trackChunkGenerator'
 
-type Props = ThreeElements['group'] & Omit<ChunkData, 'id'>
+interface GroupProps extends Omit<ThreeElements['group'], 'id'> { id?: never }
+type Props = GroupProps & Omit<ChunkData, 'id'>
 
 const TrackChunk = forwardRef<Group, Props>(
-  ({ lanes, length, startZ, ...props }, ref) => {
+  ({ id: _discard, lanes, length, startZ, ...props }, ref) => {
+    void _discard
     const laneWidth = Math.abs(lanes[1] - lanes[0])
     return (
       <group ref={ref} position={[0, 0, startZ]} {...props}>

--- a/token-trek/src/components/obstacles/PromptInjectionCube.tsx
+++ b/token-trek/src/components/obstacles/PromptInjectionCube.tsx
@@ -12,7 +12,9 @@ import { useTrackStore } from '../../store/trackStore'
  */
 const SPEED = 5
 
-const PromptInjectionCube: FC<ThreeElements['mesh']> = (props) => {
+interface MeshProps extends Omit<ThreeElements['mesh'], 'id'> { id?: never }
+const PromptInjectionCube: FC<MeshProps> = ({ id: _discard, ...props }) => {
+  void _discard
   const meshRef = useRef<Mesh>(null!)
   const active = useGameStore((s) => s.systemPromptActive)
   const isGameOver = useGameStore((s) => s.isGameOver)

--- a/token-trek/src/components/obstacles/RateLimitGate.tsx
+++ b/token-trek/src/components/obstacles/RateLimitGate.tsx
@@ -11,7 +11,9 @@ import { useTrackStore } from '../../store/trackStore'
  */
 const SPEED = 5
 
-const RateLimitGate: FC<ThreeElements['group']> = (props) => {
+interface GroupProps extends Omit<ThreeElements['group'], 'id'> { id?: never }
+const RateLimitGate: FC<GroupProps> = ({ id: _discard, ...props }) => {
+  void _discard
   const leftRef = useRef<Mesh>(null!)
   const rightRef = useRef<Mesh>(null!)
   const groupRef = useRef<Mesh>(null!)

--- a/token-trek/src/components/obstacles/SequenceLengthWall.tsx
+++ b/token-trek/src/components/obstacles/SequenceLengthWall.tsx
@@ -9,7 +9,7 @@ import { useTrackStore } from '../../store/trackStore'
 /**
  * A wall that appears after a delay, forcing the player to jump.
  */
-type MeshProps = ThreeElements['mesh']
+interface MeshProps extends Omit<ThreeElements['mesh'], 'id'> { id?: never }
 
 interface Props extends MeshProps {
   appearAfter?: number
@@ -17,7 +17,8 @@ interface Props extends MeshProps {
 
 const SPEED = 5
 
-const SequenceLengthWall: FC<Props> = ({ appearAfter = 30, ...props }) => {
+const SequenceLengthWall: FC<Props> = ({ id: _discard, appearAfter = 30, ...props }) => {
+  void _discard
   const meshRef = useRef<Mesh>(null!)
   const isGameOver = useGameStore((s) => s.isGameOver)
   const isGameWon = useGameStore((s) => s.isGameWon)


### PR DESCRIPTION
## Summary
- fix runtime crash by stripping accidental `id` props from mesh/group components
- update tasks to mark *Stabilize GameScene* as complete

## Testing
- `pnpm build`
- `pnpm lint`
- `pnpm test`
