### PR TITLE
Fix movement direction and add gameplay tips

### DIFF
--- a/token-trek/src/components/Obstacle.tsx
+++ b/token-trek/src/components/Obstacle.tsx
@@ -26,8 +26,8 @@ const Obstacle = forwardRef<Mesh, MeshProps>(({ id: _discard, ...props }, ref) =
 
   useFrame((_, dt) => {
     if (isGameOver || isGameWon) return
-    meshRef.current.position.z -= SPEED * dt
-    if (meshRef.current.position.z < -5) reset()
+    meshRef.current.position.z += SPEED * dt
+    if (meshRef.current.position.z > 5) reset()
   })
 
   return (

--- a/token-trek/src/components/RAGPortal.tsx
+++ b/token-trek/src/components/RAGPortal.tsx
@@ -37,14 +37,14 @@ const RAGPortal: FC<MeshProps> = ({ id: _discard, ...props }) => {
     if (isGameOver || isGameWon) return
     const mesh = meshRef.current
     mesh.rotation.y += dt
-    mesh.position.z -= SPEED * dt
-    if (mesh.position.z < -5) {
+    mesh.position.z += SPEED * dt
+    if (mesh.position.z > 5) {
       reset()
       return
     }
     if (
-      mesh.position.z <= 0 &&
-      mesh.position.z > -1 &&
+      mesh.position.z >= 0 &&
+      mesh.position.z < 1 &&
       Math.abs(mesh.position.x - lanes[lane]) < 0.1
     ) {
       activate()

--- a/token-trek/src/components/StartMenu.tsx
+++ b/token-trek/src/components/StartMenu.tsx
@@ -22,6 +22,12 @@ const StartMenu: FC<Props> = ({ onStart }) => {
       <div style={{ fontSize: '2rem', marginBottom: '1rem' }}>Token Trek</div>
       <div style={{ marginBottom: '0.5rem' }}>High Score: {highScore.toFixed(0)}</div>
       <button onClick={onStart}>Start</button>
+      <div style={{ marginTop: '1rem', fontSize: '0.9rem' }}>
+        Use A/D or ←/→ to switch lanes, Space to jump.<br />
+        Collect <span style={{ color: 'cyan' }}>cyan tokens</span> and avoid
+        <span style={{ color: 'red' }}> red cubes</span> &amp; gates.<br />
+        The blue portal sends you to a bonus lane for extra tokens.
+      </div>
     </div>
   )
 }

--- a/token-trek/src/components/Token.tsx
+++ b/token-trek/src/components/Token.tsx
@@ -38,15 +38,15 @@ const Token: FC<MeshProps> = ({ id: _discard, ...props }) => {
     if (isGameOver || isGameWon) return
     const mesh = meshRef.current
     mesh.rotation.y += delta * 2
-    mesh.position.z -= (ragPortalActive ? SPEED * 1.5 : SPEED) * delta
-    if (mesh.position.z < -5) {
+    mesh.position.z += (ragPortalActive ? SPEED * 1.5 : SPEED) * delta
+    if (mesh.position.z > 5) {
       resetToken()
       return
     }
     const offset = ragPortalActive ? BONUS_OFFSET : 0
     if (
-      mesh.position.z <= 0 &&
-      mesh.position.z > -1 &&
+      mesh.position.z >= 0 &&
+      mesh.position.z < 1 &&
       Math.abs(mesh.position.x - (lanes[lane] + offset)) < 0.1
     ) {
       collectToken()

--- a/token-trek/src/components/__tests__/GameScene.test.tsx
+++ b/token-trek/src/components/__tests__/GameScene.test.tsx
@@ -1,5 +1,4 @@
 import { describe, it, expect } from 'vitest'
-import React from 'react'
 import { createRoot } from '@react-three/fiber'
 import type { WebGLRenderer } from 'three'
 
@@ -30,7 +29,7 @@ const fakeRenderer = {
   setSize() {},
   setPixelRatio() {},
   domElement: makeCanvas(),
-  shadowMap: {} as any,
+  shadowMap: {} as unknown as WebGLRenderer['shadowMap'],
   xr: {
     enabled: false,
     isPresenting: false,
@@ -51,7 +50,10 @@ describe('GameScene', () => {
     const root = createRoot(canvas)
 
     // React-Three-Fiber v8: `configure` lets us inject the stub renderer.
-    root.configure({ gl: fakeRenderer, size: { width: 1, height: 1 } })
+    root.configure({
+      gl: fakeRenderer,
+      size: { width: 1, height: 1, top: 0, left: 0 },
+    })
 
     // Lazy import to avoid pulling in the whole scene up-front.
     const { default: GameScene } = await import('../GameScene')

--- a/token-trek/src/components/obstacles/PromptInjectionCube.tsx
+++ b/token-trek/src/components/obstacles/PromptInjectionCube.tsx
@@ -41,8 +41,8 @@ const PromptInjectionCube: FC<MeshProps> = ({ id: _discard, ...props }) => {
     if (!mesh) return
     mesh.rotation.x += delta
     mesh.rotation.y += delta
-    mesh.position.z -= SPEED * delta
-    if (mesh.position.z < -5) reset()
+    mesh.position.z += SPEED * delta
+    if (mesh.position.z > 5) reset()
   })
 
   return (

--- a/token-trek/src/components/obstacles/RateLimitGate.tsx
+++ b/token-trek/src/components/obstacles/RateLimitGate.tsx
@@ -37,8 +37,8 @@ const RateLimitGate: FC<GroupProps> = ({ id: _discard, ...props }) => {
     leftRef.current.position.x = -1 - offset
     rightRef.current.position.x = 1 + offset
     if (groupRef.current) {
-      groupRef.current.position.z -= SPEED * dt
-      if (groupRef.current.position.z < -5) reset()
+      groupRef.current.position.z += SPEED * dt
+      if (groupRef.current.position.z > 5) reset()
     }
   })
   return (

--- a/token-trek/src/components/obstacles/SequenceLengthWall.tsx
+++ b/token-trek/src/components/obstacles/SequenceLengthWall.tsx
@@ -43,8 +43,8 @@ const SequenceLengthWall: FC<Props> = ({ id: _discard, appearAfter = 30, ...prop
     if (!mesh) return
     const elapsed = clock.getElapsedTime() - startTime.current
     if (elapsed >= appearAfter) mesh.visible = true
-    mesh.position.z -= SPEED * dt
-    if (mesh.position.z < -5) reset(clock.getElapsedTime())
+    mesh.position.z += SPEED * dt
+    if (mesh.position.z > 5) reset(clock.getElapsedTime())
   })
 
   return (

--- a/token-trek/src/store/trackStore.ts
+++ b/token-trek/src/store/trackStore.ts
@@ -17,7 +17,9 @@ export const useTrackStore = create<TrackState>(() => {
       const chunk = gen.next().value
       const laneIndex = lane ?? Math.floor(Math.random() * chunk.lanes.length)
       const x = chunk.lanes[laneIndex]
-      const z = chunk.startZ + Math.random() * chunk.length
+      const z = -(
+        chunk.startZ + Math.random() * chunk.length
+      )
       return { x, z }
     },
   }


### PR DESCRIPTION
## Summary
- spawn track objects in front of the player and move them toward the camera
- adjust object reset logic and chunk recycling for the new direction
- switch all obstacles, tokens and portal to move forward
- show basic controls and item hints on the start menu
- fix type error in GameScene test

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`
