### PR TITLE
Fix spawn distance for endless runner

### DIFF
--- a/token-trek/src/components/GameScene.tsx
+++ b/token-trek/src/components/GameScene.tsx
@@ -31,7 +31,7 @@ const SceneContent: FC = () => {
   const genericRefs = useRef([...Array(GENERIC_COUNT)].map(() => createRef<Mesh>()))
   const cubeRefs = useRef([...Array(CUBE_COUNT)].map(() => createRef<Mesh>()))
   const gateRefs = useRef([...Array(GATE_COUNT)].map(() => createRef<Mesh>()))
-  const wallRef = useRef<Mesh>(null!)
+  const wallRef = createRef<Mesh>()
 
   /* procedural track */
   const chunkGen = useRef(trackChunkGenerator())
@@ -115,15 +115,15 @@ const SceneContent: FC = () => {
       ))}
 
       {/* Player */}
-      <Player
-        position={[0, 0.5, 0]}
-        obstacles={[
-          ...genericRefs.current,
-          ...cubeRefs.current,
-          ...gateRefs.current,
-          wallRef,
-        ]}
-      />
+      {(() => {
+        const obstacleRefs: React.RefObject<Mesh>[] = [
+          ...(genericRefs.current as React.RefObject<Mesh>[]),
+          ...(cubeRefs.current as React.RefObject<Mesh>[]),
+          ...(gateRefs.current as React.RefObject<Mesh>[]),
+          wallRef as React.RefObject<Mesh>,
+        ]
+        return <Player position={[0, 0.5, 0]} obstacles={obstacleRefs} />
+      })()}
 
       {/* Collectibles & power‑ups */}
       {Array.from({ length: 15 }).map((_, i) => (

--- a/token-trek/src/store/trackStore.ts
+++ b/token-trek/src/store/trackStore.ts
@@ -12,13 +12,20 @@ interface TrackState {
 
 export const useTrackStore = create<TrackState>(() => {
   const gen: Generator<TrackChunk> = trackChunkGenerator()
+  const SPAWN_LIMIT = 100
   return {
+    /**
+     * Returns a lane-aligned position some distance ahead of the
+     * player. Objects spawned using this helper stay within
+     * {@link SPAWN_LIMIT} units in front of the camera so they
+     * appear regularly instead of thousands of units away.
+     */
     nextPosition: (lane?: number) => {
       const chunk = gen.next().value
       const laneIndex = lane ?? Math.floor(Math.random() * chunk.lanes.length)
       const x = chunk.lanes[laneIndex]
       const z = -(
-        chunk.startZ + Math.random() * chunk.length
+        (chunk.startZ % SPAWN_LIMIT) + Math.random() * chunk.length
       )
       return { x, z }
     },


### PR DESCRIPTION
## Summary
- limit object spawn distance using modulo in `trackStore`
- cast obstacle refs to fix strict typing in `GameScene`

## Testing
- `pnpm build`
- `pnpm test --run`
- `pnpm lint`
