### PR TITLE
Improve gameplay feedback and power-up motion

### DIFF
--- a/token-trek/src/components/Player.tsx
+++ b/token-trek/src/components/Player.tsx
@@ -2,7 +2,7 @@ import type { FC, RefObject, MutableRefObject } from 'react'
 import { useEffect, useRef } from 'react'
 import type { ThreeElements } from '@react-three/fiber'
 import { useFrame } from '@react-three/fiber'
-import type { Mesh, Box3 } from 'three'
+import type { Mesh, Box3, MeshStandardMaterial } from 'three'
 import { Box3 as ThreeBox3 } from 'three'
 
 import { contextWindowClamp } from '../game/contextWindowClamp'
@@ -34,6 +34,7 @@ const Player: FC<PlayerProps> = ({
 }) => {
   void _discard
   const meshRef   = useRef<Mesh>(null!)
+  const materialRef = useRef<MeshStandardMaterial>(null!)
   const velocityY = useRef(0)
   const jumping   = useRef(false)
   const internalCollided = useRef<Set<Mesh>>(new Set())
@@ -50,6 +51,8 @@ const Player: FC<PlayerProps> = ({
   const isGameOver  = useGameStore((s) => s.isGameOver)
   const isGameWon   = useGameStore((s) => s.isGameWon)
   const ragPortalActive = useGameStore((s) => s.ragPortalActive)
+  const lastDamage  = useGameStore((s) => s.lastDamageTime)
+  const lastToken   = useGameStore((s) => s.lastTokenTime)
 
   /* Keyboard controls */
   useEffect(() => {
@@ -66,6 +69,22 @@ const Player: FC<PlayerProps> = ({
     window.addEventListener('keydown', onKeyDown)
     return () => window.removeEventListener('keydown', onKeyDown)
   }, [lane, setLane])
+
+  /* Visual feedback on damage */
+  useEffect(() => {
+    if (!materialRef.current || !lastDamage) return
+    materialRef.current.color.set('red')
+    const id = setTimeout(() => materialRef.current?.color.set('hotpink'), 200)
+    return () => clearTimeout(id)
+  }, [lastDamage])
+
+  /* Visual feedback on token */
+  useEffect(() => {
+    if (!materialRef.current || !lastToken) return
+    materialRef.current.color.set('cyan')
+    const id = setTimeout(() => materialRef.current?.color.set('hotpink'), 200)
+    return () => clearTimeout(id)
+  }, [lastToken])
 
   /* Per-frame logic */
   useFrame((_, dt) => {
@@ -102,7 +121,7 @@ const Player: FC<PlayerProps> = ({
   return (
     <mesh ref={meshRef} {...props} position={[0, FLOOR_Y, 0]}>
       <boxGeometry args={[1, 1, 1]} />
-      <meshStandardMaterial color="hotpink" />
+      <meshStandardMaterial ref={materialRef} color="hotpink" />
     </mesh>
   )
 }

--- a/token-trek/src/components/StartMenu.tsx
+++ b/token-trek/src/components/StartMenu.tsx
@@ -24,9 +24,11 @@ const StartMenu: FC<Props> = ({ onStart }) => {
       <button onClick={onStart}>Start</button>
       <div style={{ marginTop: '1rem', fontSize: '0.9rem' }}>
         Use A/D or ←/→ to switch lanes, Space to jump.<br />
-        Collect <span style={{ color: 'cyan' }}>cyan tokens</span> and avoid
-        <span style={{ color: 'red' }}> red cubes</span> &amp; gates.<br />
-        The blue portal sends you to a bonus lane for extra tokens.
+        Collect <span style={{ color: 'cyan' }}>cyan spheres</span> for points
+        and avoid <span style={{ color: 'red' }}>red cubes</span> or
+        <span style={{ color: 'orange' }}> orange gates</span>.<br />
+        <span style={{ color: 'yellow' }}>Yellow icosahedrons</span> clear
+        obstacles briefly. The blue portal leads to a bonus lane.
       </div>
     </div>
   )

--- a/token-trek/src/components/SystemPromptPowerUp.tsx
+++ b/token-trek/src/components/SystemPromptPowerUp.tsx
@@ -36,14 +36,14 @@ const SystemPromptPowerUp: FC<MeshProps> = ({ id: _discard, ...props }) => {
     if (isGameOver || isGameWon) return
     const mesh = meshRef.current
     mesh.rotation.y += dt
-    mesh.position.z -= trackSpeed * dt
-    if (mesh.position.z < -5) {
+    mesh.position.z += trackSpeed * dt
+    if (mesh.position.z > 5) {
       reset()
       return
     }
     if (
-      mesh.position.z <= 0 &&
-      mesh.position.z > -1 &&
+      mesh.position.z >= 0 &&
+      mesh.position.z < 1 &&
       Math.abs(mesh.position.x - lanes[lane]) < 0.1
     ) {
       activate()

--- a/token-trek/src/store/gameStore.ts
+++ b/token-trek/src/store/gameStore.ts
@@ -13,6 +13,8 @@ interface GameState {
   reduceHealth: (amount: number) => void
   resetHealth: () => void
   shrinkMaxHealth: (amount: number) => void
+  lastDamageTime: number
+  lastTokenTime: number
 
   /* Power-ups */
   systemPromptActive: boolean
@@ -45,11 +47,17 @@ export const useGameStore = create<GameState>((set, get) => ({
   maxHealth: 100,
   isGameOver: false,
   isGameWon: false,
+  lastDamageTime: 0,
+  lastTokenTime: 0,
   reduceHealth: (amount) =>
     set((state) => {
       const nextHealth = Math.max(state.health - amount, 0)
       playCollision()
-      return { health: nextHealth, isGameOver: nextHealth <= 0 }
+      return {
+        health: nextHealth,
+        isGameOver: nextHealth <= 0,
+        lastDamageTime: performance.now(),
+      }
     }),
   resetHealth: () =>
     set({ health: 100, maxHealth: 100, isGameOver: false, isGameWon: false }),
@@ -109,6 +117,7 @@ export const useGameStore = create<GameState>((set, get) => ({
         tokenCount,
         multiplier: state.multiplier + 1,
         isGameWon: tokenCount >= AGI_GOAL,
+        lastTokenTime: performance.now(),
       }
     }),
   tokensPerSecond: () => {
@@ -145,6 +154,8 @@ export const useGameStore = create<GameState>((set, get) => ({
         isGameWon: false,
         systemPromptActive: false,
         ragPortalActive: false,
+        lastDamageTime: 0,
+        lastTokenTime: 0,
         tokenCount: 0,
         multiplier: 1,
         startTime: performance.now(),


### PR DESCRIPTION
## Summary
- make player flash cyan or red when collecting tokens or taking damage
- clarify instructions in the start menu
- move system prompt power-up toward the player
- add timestamps to the game store for token and damage events

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`
